### PR TITLE
run mlflow pod in dedicated node to mount ssd pvc

### DIFF
--- a/k8s/mlflow.yaml
+++ b/k8s/mlflow.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: mlflow
+        pod.staroid.com/isolation: dedicated
     spec:
       initContainers:
       - name: mlflow-db-upgrade
@@ -32,13 +33,6 @@ spec:
           --backend-store-uri postgresql://mlflow:mlflow@postgres:5432/mlflow
           --default-artifact-root /mlruns
           --host 0.0.0.0
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "512Mi"
-          limits:
-            cpu: "2"
-            memory: "2048Mi"
         volumeMounts:
           - name: mlflow-artifact-volume
             mountPath: /mlruns
@@ -68,3 +62,4 @@ spec:
   resources:
     requests:
       storage: 20Gi
+---

--- a/k8s/mlflow.yaml
+++ b/k8s/mlflow.yaml
@@ -13,6 +13,8 @@ spec:
         app: mlflow
         pod.staroid.com/isolation: dedicated
     spec:
+      securityContext:
+        fsGroup: 2000 # To mount mlruns volume with access permission. fyi, 'sandboxed' does not support fsGroup
       initContainers:
       - name: mlflow-db-upgrade
         image: mlflow


### PR DESCRIPTION
Staroid currently support ssd type volume only in pod with `isolation: deidcated`. see https://docs.staroid.com/virtual_cloud/storage.html#storageclassname.

Therefore adding a label to make pod run in dedicated node.

Alternative is run pod with `isolation: sandboxed` and use `nfs` volume. However, `nfs` is relatively slow and I think artifact storage needs higher throughput.