### PR TITLE
setup sftp artifact store

### DIFF
--- a/Dockerfile_sftp
+++ b/Dockerfile_sftp
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y openssh-server && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 2000 mlflow && \
-    useradd -ms /bin/bash -d /home/mlflow mlflow --uid 2000 --gid 2000
+    useradd -ms /bin/bash -d /home/mlflow mlflow --uid 2000 --gid 2000 && \
+    echo "+:mlflow:ALL" >> /etc/security/access.conf
 
 # on sftp login, motd requires write permissions on some dir. TODO disable motd
 RUN mkdir -p /run && chown mlflow:mlflow -R /run && \

--- a/Dockerfile_sftp
+++ b/Dockerfile_sftp
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+ADD ssh-key-gen.sh /usr/local/bin/
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.3/bin/linux/amd64/kubectl /usr/bin/kubectl
+RUN chmod +rx /usr/bin/kubectl
+
+RUN apt-get update && apt-get install -y openssh-server && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 2000 mlflow && \
+    useradd -ms /bin/bash -d /home/mlflow mlflow --uid 2000 --gid 2000
+
+# on sftp login, motd requires write permissions on some dir. TODO disable motd
+RUN mkdir -p /run && chown mlflow:mlflow -R /run && \
+    mkdir -p /var/cache && chown mlflow:mlflow -R /var/cache
+
+USER 2000

--- a/Dockerfile_sftp
+++ b/Dockerfile_sftp
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y openssh-server && \
 
 RUN groupadd --gid 2000 mlflow && \
     useradd -ms /bin/bash -d /home/mlflow mlflow --uid 2000 --gid 2000 && \
-    echo "+:mlflow:ALL" >> /etc/security/access.conf
+    sed -i 's/^UsePAM.*/UsePAM no/' /etc/ssh/sshd_config
 
 # on sftp login, motd requires write permissions on some dir. TODO disable motd
 RUN mkdir -p /run && chown mlflow:mlflow -R /run && \

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ $ skaffold dev --port-forward -p minikube
 ```
 
 and browse `http://localhost:5000`
+
+
+### Clean up
+
+It creates secret `mlflow-ssh-key` dynamically. Skaffold does not remove this one. Clean up resource with
+
+```
+$ kubectl delete secret mlflow-ssh-key
+```
+

--- a/k8s/minikube.yaml
+++ b/k8s/minikube.yaml
@@ -17,3 +17,35 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 provisioner: k8s.io/minikube-hostpath
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: staroid-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "pods/exec", "pods/binding", "services", "secrets", "configmaps", "persistentvolumeclaims"]
+  verbs: ["create", "get", "update", "patch", "list", "delete", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["create", "get", "update", "patch", "list", "delete", "watch"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames: ['crt-user-psp']
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: staroid-rolebinding
+roleRef:
+  kind: Role
+  name: staroid-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+---

--- a/k8s/mlflow-env.yaml
+++ b/k8s/mlflow-env.yaml
@@ -6,4 +6,6 @@ metadata:
     # see https://docs.staroid.com/project/dependency.html
     dependency.staroid.com/export: mlflow-env
 data:
-  MLFLOW_TRACKING_URI: "mlflow.{{.Namespace}}"
+  MLFLOW_TRACKING_URI: "http://mlflow.{{.Namespace}}:5000"
+  MLFLOW_ARTIFACT_STORE_RSA_PUB: "" # for passwordless sftp access to the artifact. ssh-key-gen.sh will update this field.
+  MLFLOW_ARTIFACT_STORE_RSA_PRI: ""

--- a/k8s/mlflow.yaml
+++ b/k8s/mlflow.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mlflow
 spec:
   replicas: 1
+  strategy:
+    type: "Recreate"
   selector:
     matchLabels:
       app: mlflow

--- a/k8s/mlflow.yaml
+++ b/k8s/mlflow.yaml
@@ -15,15 +15,6 @@ spec:
     spec:
       securityContext:
         fsGroup: 2000 # To mount mlruns volume with access permission. fyi, 'sandboxed' does not support fsGroup
-      initContainers:
-      - name: mlflow-db-upgrade
-        image: mlflow
-        command: 
-        - "bash"
-        - "-c"
-        - "date"
-        #- >-
-        #  mlflow db upgrade postgresql://mlflow:mlflow@postgres:5432/mlflow      
       containers:
       - name: mlflow
         image: mlflow
@@ -31,17 +22,49 @@ spec:
         - "bash"
         - "-c"
         - >-
+          mkdir -p /home/mlflow/.ssh && chmod 700 /home/mlflow/.ssh &&
+          echo -n "mlflow.$POD_NAMESPACE " >> /home/mlflow/.ssh/known_hosts &&
+          cat /ssh-key/id_rsa.pub >> /home/mlflow/.ssh/known_hosts &&
+          cp /ssh-key/id_rsa /home/mlflow/.ssh/ &&
+          chmod 600 /home/mlflow/.ssh/* &&
           mlflow server
           --backend-store-uri postgresql://mlflow:mlflow@postgres:5432/mlflow
-          --default-artifact-root /mlruns
+          --default-artifact-root sftp://mlflow@mlflow.$POD_NAMESPACE:10022/mlruns
           --host 0.0.0.0
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
           - name: mlflow-artifact-volume
             mountPath: /mlruns
+          - name: ssh-key-volume
+            mountPath: /ssh-key
+      - name: artifact-store
+        image: sftp
+        command:
+        - "bash"
+        - "-c"
+        - >-
+          mkdir -p /home/mlflow/.ssh/ && chmod 700 /home/mlflow/.ssh &&
+          cp /ssh-key/* /home/mlflow/.ssh/ &&
+          mv /home/mlflow/.ssh/id_rsa.pub /home/mlflow/.ssh/authorized_keys &&
+          chmod 600 /home/mlflow/.ssh/* &&
+          /usr/sbin/sshd -e -D -h /home/mlflow/.ssh/id_rsa -p 10022
+        volumeMounts:
+          - name: mlflow-artifact-volume
+            mountPath: /mlruns
+          - name: ssh-key-volume
+            mountPath: /ssh-key
       volumes:
         - name: mlflow-artifact-volume
           persistentVolumeClaim:
             claimName: mlflow-artifact-pvc
+        - name: ssh-key-volume
+          secret:
+            secretName: mlflow-ssh-key
+            defaultMode: 0600
 ---
 kind: Service
 apiVersion: v1
@@ -49,7 +72,10 @@ metadata:
   name: mlflow
 spec:
   ports:
-  - port: 5000
+  - name: mlflow
+    port: 5000
+  - name: sftp
+    port : 10022  # sftp for artifact
   selector:
     app: mlflow
 ---

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -4,6 +4,8 @@ metadata:
   name: postgres-deployment
 spec:
   replicas: 1
+  strategy:
+    type: "Recreate"
   selector:
     matchLabels:
       app: postgres

--- a/k8s/sshkeygen.yaml
+++ b/k8s/sshkeygen.yaml
@@ -1,0 +1,20 @@
+# generate new ssh key and create Secret if not exists
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Unique key of the Job instance
+  name: ssh-keygen
+spec:
+  # of retries before marking as failed.
+  backoffLimit: 1
+  template:
+    metadata:
+      name: ssh-keygen
+    spec:
+      automountServiceAccountToken: true
+      # Do not restart containers after they exit
+      restartPolicy: Never
+      containers:
+      - name: ssh-keygen
+        image: sftp
+        command: ["/usr/local/bin/ssh-key-gen.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mlflow==1.9.1
 psycopg2==2.8.5
+pysftp==0.2.9

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,10 +5,16 @@ build:
     - image: mlflow
       context: .
       docker:
-        dockerfile: Dockerfile 
+        dockerfile: Dockerfile
+    - image: sftp
+      context: .
+      docker:
+        dockerfile: Dockerfile_sftp
 deploy:
   kubectl:
     manifests:
+      - k8s/mlflow-env.yaml
+      - k8s/sshkeygen.yaml
       - k8s/postgres.yaml
       - k8s/mlflow.yaml
 profiles:

--- a/ssh-key-gen.sh
+++ b/ssh-key-gen.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+ENV_CONFIGMAP_NAME=mlflow-env
+SSH_KEY_SECRET_NAME=mlflow-ssh-key
+
+# check if ssh key secret already exists
+kubectl get secret $SSH_KEY_SECRET_NAME
+if [ $? -eq 0 ]; then
+  exit 0
+fi
+
+echo "Generate a new ssh-key"
+
+# generate ssh key pair /tmp/id_rsa and /tmp/id_rsa.pub
+ssh-keygen -b 2048 -t rsa -f /tmp/id_rsa -q -N ""
+
+# create secret
+echo "create secret $SSH_KEY_SECRET_NAME"
+kubectl create secret generic $SSH_KEY_SECRET_NAME \
+  --from-file=/tmp/id_rsa \
+  --from-file=/tmp/id_rsa.pub
+
+# update configmap
+echo "update $ENV_CONFIGMAP_NAME"
+kubectl get configmap $ENV_CONFIGMAP_NAME -o yaml > /tmp/$ENV_CONFIGMAP_NAME
+PUBLIC_KEY=`cat /tmp/id_rsa.pub | base64 -w 0`
+PRIVATE_KEY=`cat /tmp/id_rsa | base64 -w 0`
+sed -i "s/  MLFLOW_ARTIFACT_STORE_RSA_PUB.*/  MLFLOW_ARTIFACT_STORE_RSA_PUB\: $PUBLIC_KEY/" /tmp/$ENV_CONFIGMAP_NAME
+sed -i "s/  MLFLOW_ARTIFACT_STORE_RSA_PRI.*/  MLFLOW_ARTIFACT_STORE_RSA_PRI\: $PRIVATE_KEY/" /tmp/$ENV_CONFIGMAP_NAME
+kubectl apply -f /tmp/$ENV_CONFIGMAP_NAME


### PR DESCRIPTION
Looks like each mlflow client accesses artifact store directly.

There's some implementation available for artifact store.
https://mlflow.org/docs/latest/tracking.html#id10

I'd like to make it work with zero external dependencies, this pr impelemnts

 - sftp server over a pvc to provide storage
 - mlflow-env export informations (ssh keys) to access sftp.